### PR TITLE
modifed to run on linux platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,22 +8,22 @@ on:
     branches:
       - master
   schedule:
-    - cron:  '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   load-test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, actions-runner-dev]
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.8]
-# TODO: We probably should switch to using the Docker version.
+    # TODO: We probably should switch to using the Docker version.
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Build Docker
-      run: |
-        docker build . 
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build Docker
+        run: |
+          docker build .

--- a/.github/workflows/productionintegration.yml
+++ b/.github/workflows/productionintegration.yml
@@ -1,27 +1,26 @@
 name: production-integration
 
-on: 
+on:
   push:
   schedule:
-   - cron:  '15 * * * *'
+    - cron: "15 * * * *"
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, actions-runner-dev]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install requests
-        pip install pandas
-    - name: Test with pytest
-      run: |
-        pip install nose2
-        cd test-integration	&& nose2 -v
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+          pip install pandas
+      - name: Test with pytest
+        run: |
+          pip install nose2
+          cd test-integration	&& nose2 -v

--- a/Classifier/models_folder/models/convert_keras_to_tf.py
+++ b/Classifier/models_folder/models/convert_keras_to_tf.py
@@ -4,7 +4,7 @@ import sys
 print(tf.__version__)
 
 # The export path contains the name and the version of the model
-tf.keras.backend.set_learning_phase(0)  # Ignore dropout at inference
+# tf.keras.backend.set_learning_phase(0)  # Ignore dropout at inference
 model = tf.keras.models.load_model(sys.argv[1])
 export_folder = sys.argv[2]
 model.save(export_folder)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:22.04
+FROM --platform=linux/amd64 ubuntu:22.04
 MAINTAINER Mingxun Wang "mwang87@gmail.com"
 
-RUN apt-get update && apt-get install -y build-essential libarchive-dev wget vim
+RUN apt-get update && apt-get install -y build-essential libarchive-dev wget vim g++ gcc make cmake git libglib2.0-0 libgl1-mesa-glx libpq-dev libsm6 libxext6 libxrender-dev
 
 # Install Mamba
 ENV CONDA_DIR /opt/conda
@@ -11,7 +11,7 @@ ENV PATH=$CONDA_DIR/bin:$PATH
 # Adding to bashrc
 RUN echo "export PATH=$CONDA_DIR:$PATH" >> ~/.bashrc
 
-RUN mamba create -n rdkit -c rdkit rdkit=2019.09.3.0
+RUN mamba create -n rdkit -c rdkit rdkit --yes
 
 COPY requirements.txt .
 RUN /bin/bash -c "source activate rdkit && pip install -r requirements.txt"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 build:
-	docker build -t npclassifier . 
+	docker build --platform linux/amd64 -t npclassifier . --no-cache
 
 bash:
-	docker run -it --rm npclassifier /bin/bash
+	docker run --platform=linux/amd64 -it --rm npclassifier /bin/bash
 
 server-compose-build-nocache:
 	docker-compose --compatibility build --no-cache

--- a/README.md
+++ b/README.md
@@ -2,8 +2,28 @@
 
 ![production-integration](https://github.com/mwang87/NP-Classifier/workflows/production-integration/badge.svg)
 
-We typically will deploy this locally. To bring everything up, 
+We typically will deploy this locally. To bring everything up,
 you need docker and docker-compose.
+
+## Montai Fork Changes
+
+**Note:** The instructions remain mostly the same, we have re-written them for clarity. Read the original instructions [here](#original-instructions)
+
+- The fork has a new branch `dev` with a small amount of modifications. Please checkout to the `dev` branch or clone the dev branch to use the fork
+- `Dockerfile` was modified to use `rdkit` the latest version, and a few more `g++` dependencies for `rdkit` were added
+- `Classifier/models_folder/models/convert_keras_to_tf.py` was modified to disable `tf.keras.backend.set_learning_phase(0)`
+- `Makefile` was modified to use `linux/amd64` platform for building, and running docker images
+
+### TLDR Instructions
+
+- In Docker Desktop for Mac, Add the path `/Users/<>/NP-Classifier/output` to `Docker -> Preferences... -> Resources -> File Sharing.` Replace `<>/` with your username/path to the `NP-Classifier` folder
+- Run `cd Classifier/models_folder/models` and `sh ./get_models.sh` to download the models
+- This will download the models to `Classifier/models_folder/models/models` and convert them to `HDF5` format
+- Run `docker network create nginx-net` to create a network
+- Run `make server-compose` to build and run the server
+- Visit `http://localhost:6541/` to view the dashboard
+
+## Original Instructions
 
 ### Local Server
 
@@ -13,6 +33,7 @@ you need docker and docker-compose.
 cd Classifier/models_folder/models
 sh ./get_models.sh
 ```
+
 NOTE: Make sure you have python installed and tensorflow version 2.3.0 installed to convert the keras models into HDF5 TF2 models.  
 
 #### Building Dockerized Server
@@ -35,14 +56,15 @@ We pass through tensorflow serving at this url:
 
 If the model input names change, then we need to change it in the code
 
-### Checking input/output layer names.
+### Checking input/output layer names
+
 Input layers' names should be "input_2048" and "input_4096"
 
 Output layer's name should be "output"
 
 ### APIs
 
-Classify programmatically 
+Classify programmatically
 
 ```/classify?smiles=<>```
 
@@ -54,4 +76,4 @@ The license as included for the software is MIT. Additionally, all data, models,
 
 ## Privacy
 
-We try our best to balance privacy and understand how users are using our tool. As such, we keep in our logs which structures were classified but not which users queried the structure. 
+We try our best to balance privacy and understand how users are using our tool. As such, we keep in our logs which structures were classified but not which users queried the structure.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ you need docker and docker-compose.
 
 ## Montai Fork Changes
 
-**Note:** The instructions remain mostly the same, we have re-written them for clarity. Read the original instructions [here](#original-instructions)
+**Note:** The instructions remain mostly the same (with some conda stuff), we have re-written them for clarity. Read the original instructions [here](#original-instructions)
 
 - The fork has a new branch `dev` with a small amount of modifications. Please checkout to the `dev` branch or clone the dev branch to use the fork
+- Run `conda create -n np-classifier python=3.8` to create a new conda environment
+- Install the latest `tensorflow` and `pandas` using `conda install tensorflow pandas`. Do not worry as the latest tensorflow is backward compatible with the models
 - `Dockerfile` was modified to use `rdkit` the latest version, and a few more `g++` dependencies for `rdkit` were added
 - `Classifier/models_folder/models/convert_keras_to_tf.py` was modified to disable `tf.keras.backend.set_learning_phase(0)`
 - `Makefile` was modified to use `linux/amd64` platform for building, and running docker images

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ you need docker and docker-compose.
 - `Dockerfile` was modified to use `rdkit` the latest version, and a few more `g++` dependencies for `rdkit` were added
 - `Classifier/models_folder/models/convert_keras_to_tf.py` was modified to disable `tf.keras.backend.set_learning_phase(0)`
 - `Makefile` was modified to use `linux/amd64` platform for building, and running docker images
+- `.github/workflows/**` was modified to use our CI on k8s
 
 ### TLDR Instructions
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ you need docker and docker-compose.
 **Note:** The instructions remain mostly the same (with some conda stuff), we have re-written them for clarity. Read the original instructions [here](#original-instructions)
 
 - The fork has a new branch `dev` with a small amount of modifications. Please checkout to the `dev` branch or clone the dev branch to use the fork
-- Run `conda create -n np-classifier python=3.8` to create a new conda environment
-- Install the latest `tensorflow` and `pandas` using `conda install tensorflow pandas`. Do not worry as the latest tensorflow is backward compatible with the models
 - `Dockerfile` was modified to use `rdkit` the latest version, and a few more `g++` dependencies for `rdkit` were added
 - `Classifier/models_folder/models/convert_keras_to_tf.py` was modified to disable `tf.keras.backend.set_learning_phase(0)`
 - `Makefile` was modified to use `linux/amd64` platform for building, and running docker images
@@ -19,8 +17,10 @@ you need docker and docker-compose.
 
 ### TLDR Instructions
 
+- Run `conda create -n np-classifier python=3.8` to create a new conda environment. Activate the environment using `conda activate np-classifier`
+- Install the latest `tensorflow` and `pandas` using `conda install tensorflow pandas`. Do not worry as the latest tensorflow is backward compatible with the models
 - In Docker Desktop for Mac, Add the path `/Users/<>/NP-Classifier/output` to `Docker -> Preferences... -> Resources -> File Sharing.` Replace `<>/` with your username/path to the `NP-Classifier` folder
-- Run `cd Classifier/models_folder/models` and `sh ./get_models.sh` to download the models
+- Run `cd Classifier/models_folder/models` and `sh ./get_models.sh` to download the models (be sure to be in the `np-classifier` conda environment when running this)
 - This will download the models to `Classifier/models_folder/models/models` and convert them to `HDF5` format
 - Run `docker network create nginx-net` to create a network
 - Run `make server-compose` to build and run the server


### PR DESCRIPTION
- The fork has a new branch `dev` with a small amount of modifications. Please checkout to the `dev` branch or clone the dev branch to use the fork
- `Dockerfile` was modified to use `rdkit` the latest version, and a few more `g++` dependencies for `rdkit` were added
- `Classifier/models_folder/models/convert_keras_to_tf.py` was modified to disable `tf.keras.backend.set_learning_phase(0)`
- `Makefile` was modified to use `linux/amd64` platform for building, and running docker images
- `.github/workflows/**` was modified to use our CI on k8s